### PR TITLE
Modify exec and rollback command to required dest

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ All other migration id generates empty migration file.
 
 ### Plan migration
 ```shell
-$ migorate plan
+$ migorate plan all
 2016/07/17 21:16:53 Planned migrations:
 2016/07/17 21:16:53   1: 20160717225530_create_users
 ```
 
 ### Execute migration
 ```shell
-$ migorate exec
+$ migorate exec all
 2016/07/17 21:17:49 Executing 20160717225530_create_users
 2016/07/17 21:17:49   CREATE TABLE users(id INT PRIMARY KEY AUTO_INCREMENT, name VARCHAR(255), login_count INT, last_login_at DATETIME, created_at TIMESTAMP);
 ```
@@ -75,4 +75,28 @@ $ migorate rollback [migration id]
 $ migorate rollback 20160717225530_create_users
 2016/07/17 21:21:09 Executing 20160717225530_create_users
 2016/07/17 21:21:09   DROP TABLE users;
+```
+
+### Rollback all
+```shell
+$ migorate rollback all
+2017/02/26 15:42:30 Executing 20160716102604_create_authors
+2017/02/26 15:42:30 Executed:
+ALTER TABLE books
+  DROP FOREIGN KEY fk_books_author_id;
+
+2017/02/26 15:42:30 Executed:
+DROP TABLE authors;
+
+2017/02/26 15:42:30 Executed:
+ALTER TABLE books
+  ADD (author VARCHAR(255));
+
+2017/02/26 15:42:30 Executing 20160714092604_create_books
+2017/02/26 15:42:30 Executed:
+DROP TABLE books;
+
+2017/02/26 15:42:30 Executing 20160714092556_create_users
+2017/02/26 15:42:30 Executed:
+DROP TABLE users;
 ```

--- a/main.go
+++ b/main.go
@@ -57,7 +57,12 @@ func main() {
 					d = migration.Down
 				}
 				path := c.GlobalString("path")
-				migrations := *migration.Plan(path, d, dest(c))
+				execFile := dest(c)
+				if len(execFile) == 0 {
+					log.Println("Please specify the file_name or 'all' to execute. ")
+					return nil
+				}
+				migrations := *migration.Plan(path, d, execFile)
 				count := len(migrations)
 				if count == 0 {
 					log.Println("No migration planned.")
@@ -86,7 +91,12 @@ func main() {
 			Usage: "execute migration",
 			Action: func(c *cli.Context) error {
 				path := c.GlobalString("path")
-				return migrate(path, migration.Up, dest(c))
+				execFile := dest(c)
+				if len(execFile) == 0 {
+					log.Println("Please specify the file_name or 'all' to execute. ")
+					return nil
+				}
+				return migrate(path, migration.Up, execFile)
 			},
 		},
 		{
@@ -94,7 +104,12 @@ func main() {
 			Usage: "rollback migration",
 			Action: func(c *cli.Context) error {
 				path := c.GlobalString("path")
-				return migrate(path, migration.Down, dest(c))
+				execFile := dest(c)
+				if len(execFile) == 0 {
+					log.Println("Please specify the file_name or 'all' to execute. ")
+					return nil
+				}
+				return migrate(path, migration.Down, execFile)
 			},
 		},
 	}

--- a/migration/migration_test.go
+++ b/migration/migration_test.go
@@ -10,7 +10,7 @@ func TestExec(t *testing.T) {
 	db := initDb()
 	defer cleanupDb(db)
 
-	migrations := Plan(testMigrationPath, Up, "")
+	migrations := Plan(testMigrationPath, Up, "all")
 	for _, m := range *migrations {
 		m.Exec(db, Up)
 	}

--- a/migration/service.go
+++ b/migration/service.go
@@ -61,7 +61,10 @@ func Plan(dir string, direction Direction, dest string) *[]Migration {
 		}
 	}
 
-	return &sqls
+	if dest == "all" {
+		return &sqls
+	}
+	return &[]Migration{}
 }
 
 func currentFilename(files []os.FileInfo, d Direction, i int) string {

--- a/migration/service_test.go
+++ b/migration/service_test.go
@@ -42,7 +42,7 @@ func TestPlan(t *testing.T) {
 	db := initDb()
 	defer cleanupDb(db)
 
-	migrations := *Plan(testMigrationPath, Up, "")
+	migrations := *Plan(testMigrationPath, Up, "all")
 	assert.Equal(t, 3, len(migrations), "Expect 2 migration found but %v found.", len(migrations))
 
 	assertCreateUsersMigration(t, migrations[0])
@@ -67,7 +67,7 @@ func TestPlanWhenAlreadyMigratedBooks(t *testing.T) {
 
 	db.Exec("INSERT INTO migorate_migrations(id, migrated_at) VALUES('20160714092604_create_books', NOW());")
 
-	migrations := *Plan(testMigrationPath, Up, "")
+	migrations := *Plan(testMigrationPath, Up, "all")
 	assert.Equal(t, 2, len(migrations), "Expect 1 migration found but %v found.", len(migrations))
 	assertCreateUsersMigration(t, migrations[0])
 	assertCreateAuthorsMigration(t, migrations[1])
@@ -79,7 +79,7 @@ func TestPlanWhenAlreadyMigrated(t *testing.T) {
 
 	db.Exec("INSERT INTO migorate_migrations(id, migrated_at) VALUES('20160714092556_create_users', NOW());")
 
-	migrations := *Plan(testMigrationPath, Up, "")
+	migrations := *Plan(testMigrationPath, Up, "all")
 	assert.Equal(t, 2, len(migrations), "Expect 1 migration found but %v found.", len(migrations))
 	assertCreateBooksMigration(t, migrations[0])
 	assertCreateAuthorsMigration(t, migrations[1])
@@ -93,7 +93,7 @@ func TestPlanRollback(t *testing.T) {
 	db.Exec("INSERT INTO migorate_migrations(id, migrated_at) VALUES('20160714092604_create_books', NOW());")
 	db.Exec("INSERT INTO migorate_migrations(id, migrated_at) VALUES('20160716102604_create_authors', NOW());")
 
-	migrations := *Plan(testMigrationPath, Down, "")
+	migrations := *Plan(testMigrationPath, Down, "all")
 	assert.Equal(t, 3, len(migrations), "Expect 2 migration found but %v found.", len(migrations))
 
 	assertCreateAuthorsMigration(t, migrations[0])


### PR DESCRIPTION
引数の指定ミスなどでrollbackとexecが全部実行されてしまう誤爆が多々あったので、 `all` とつけた時以外は、rollbackとexecコマンドで全部実行しないようにしました。
