### PR TITLE
Fix migorate_migrations table key size 255 -> 64

### DIFF
--- a/migration/db/mysql/db.go
+++ b/migration/db/mysql/db.go
@@ -45,7 +45,7 @@ func Database() *sql.DB {
 		log.Fatalf("Failed to open database: %v\n", err)
 	}
 
-	_, err = db.Exec("CREATE TABLE IF NOT EXISTS migorate_migrations(id VARCHAR(255) PRIMARY KEY, migrated_at TIMESTAMP);")
+	_, err = db.Exec("CREATE TABLE IF NOT EXISTS migorate_migrations(id VARCHAR(64) PRIMARY KEY, migrated_at TIMESTAMP);")
 	if err != nil {
 		log.Fatalf("Failed to create migration management table: %v\n", err)
 	}


### PR DESCRIPTION
```
Failed to create migration management table: Error 1071: Specified key was too long; max key length is 767 bytes
```