### PR TITLE
Fix support rc flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,6 +21,11 @@ func main() {
 			Usage: "migrations files directory path",
 			Value: "db/migrations",
 		},
+		cli.StringFlag{
+			Name:  "rc",
+			Usage: "migrations configuration file directory path",
+			Value: mysql.RCFilePath,
+		},
 	}
 
 	app.Commands = []cli.Command{
@@ -57,6 +62,7 @@ func main() {
 					d = migration.Down
 				}
 				path := c.GlobalString("path")
+				mysql.RCFilePath = c.GlobalString("rc")
 				execFile := dest(c)
 				if len(execFile) == 0 {
 					log.Println("Please specify the file_name or 'all' to execute. ")
@@ -91,6 +97,7 @@ func main() {
 			Usage: "execute migration",
 			Action: func(c *cli.Context) error {
 				path := c.GlobalString("path")
+				mysql.RCFilePath = c.GlobalString("rc")
 				execFile := dest(c)
 				if len(execFile) == 0 {
 					log.Println("Please specify the file_name or 'all' to execute. ")
@@ -104,6 +111,7 @@ func main() {
 			Usage: "rollback migration",
 			Action: func(c *cli.Context) error {
 				path := c.GlobalString("path")
+				mysql.RCFilePath = c.GlobalString("rc")
 				execFile := dest(c)
 				if len(execFile) == 0 {
 					log.Println("Please specify the file_name or 'all' to execute. ")

--- a/migration/db/mysql/db.go
+++ b/migration/db/mysql/db.go
@@ -9,6 +9,9 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// RCFilePath configuration file path
+var RCFilePath = ".migoraterc"
+
 // RunCommand is configuration for database connection
 type RunCommand struct {
 	Host     string
@@ -24,14 +27,14 @@ type mySQLRunCommand struct {
 }
 
 func loadRc() *mySQLRunCommand {
-	buf, err := ioutil.ReadFile(".migoraterc")
+	buf, err := ioutil.ReadFile(RCFilePath)
 	if err != nil {
-		log.Fatalf("Failed to load .migoraterc: %v\n", err)
+		log.Fatalf("Failed to load %s: %v\n", RCFilePath, err)
 	}
 	m := mySQLRunCommand{}
 	err = yaml.Unmarshal(buf, &m)
 	if err != nil {
-		log.Fatalf("Failed to load .migoraterc as YAML: %v\n", err)
+		log.Fatalf("Failed to load %s as YAML: %v\n", RCFilePath, err)
 	}
 	return &m
 }

--- a/migration/db/mysql/db_test.go
+++ b/migration/db/mysql/db_test.go
@@ -38,9 +38,9 @@ func TestDatabase(t *testing.T) {
 
 func createTestRc() {
 	buf, _ := ioutil.ReadFile("../../../test/rc/mysql.yml")
-	ioutil.WriteFile(".migoraterc", buf, os.ModePerm)
+	ioutil.WriteFile(RCFilePath, buf, os.ModePerm)
 }
 
 func removeTestRc() {
-	os.Remove(".migoraterc")
+	os.Remove(RCFilePath)
 }

--- a/migration/service_test.go
+++ b/migration/service_test.go
@@ -154,7 +154,7 @@ func assertEqualStripQuery(t *testing.T, expected, received string) {
 
 func initDb() *sql.DB {
 	buf, _ := ioutil.ReadFile("../test/rc/mysql.yml")
-	ioutil.WriteFile(".migoraterc", buf, os.ModePerm)
+	ioutil.WriteFile(mysql.RCFilePath, buf, os.ModePerm)
 
 	db := mysql.Database()
 	cleanUpTables(db)
@@ -162,7 +162,7 @@ func initDb() *sql.DB {
 }
 
 func cleanupDb(db *sql.DB) {
-	os.Remove(".migoraterc")
+	os.Remove(mysql.RCFilePath)
 	cleanUpTables(db)
 	db.Close()
 }


### PR DESCRIPTION
環境ごとにportやhostなどを分けているときに `.migoraterc` を指定できればだいぶ楽になりそうだなぁ〜と思って起動引数追加してみました 😄 

```
$ migorate -rc .migoraterc.dev -p _db/migrations/ plan all
2018/08/01 23:52:59 Planned migrations:
2018/08/01 23:52:59   1: 20180616100000_create_table
```