### PR TITLE
fix: 正規表現にマッチしなかった時にidを出力する

### DIFF
--- a/migration/migration.go
+++ b/migration/migration.go
@@ -32,6 +32,9 @@ func NewMigration(dir string, id string) Migration {
 	b, _ := ioutil.ReadFile(dir + "/" + id + ".sql")
 	r := regexp.MustCompile(`(?m)-- \+migrate Up\n([\s\S]*)\n-- \+migrate Down\n([\s\S]*)`)
 	sqls := r.FindSubmatch(b)
+	if len(sqls) == 0 {
+		log.Fatalf("Invalid file format: %s\n", id)
+	}
 	up := splitSQL(string(sqls[1]))
 	down := splitSQL(string(sqls[2]))
 	return Migration{ID: id, Up: up, Down: down}


### PR DESCRIPTION
ファイルのフォーマット違反があった時、panicが発生します。

```txt
panic: runtime error: index out of range [1] with length 0

goroutine 1 [running]:
github.com/ClusterVR/migorate/migration.NewMigration({0x7fffbcfb6aff, 0xf}, {0xc000155b80, 0x46})
...
```

エラーの原因が分かりにくいので、問題のあるファイルが特定しやすいように、idを出力するようにしました。